### PR TITLE
feat: 동행 게시물 이미지 주소 CRUD 기능 추가

### DIFF
--- a/src/main/java/web/trivi/controller/AccBoardApiController.java
+++ b/src/main/java/web/trivi/controller/AccBoardApiController.java
@@ -6,10 +6,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import web.trivi.domain.AccompanyBoard;
-import web.trivi.dto.AccBoardResponse;
-import web.trivi.dto.AddAccBoardRequest;
-import web.trivi.dto.UpdateAccBoardRequest;
+import web.trivi.domain.BoardImage;
+import web.trivi.domain.BoardType;
+import web.trivi.dto.*;
 import web.trivi.service.AccBoardService;
+import web.trivi.service.ImgPathSaveService;
+import java.util.stream.Collectors;
 
 import java.security.Principal;
 import java.util.List;
@@ -19,6 +21,7 @@ import java.util.List;
 public class AccBoardApiController {
 
     private final AccBoardService accBoardService;
+    private final ImgPathSaveService imgPathSaveService;
 
     @PostMapping("/api/accompany")
     public ResponseEntity<AccompanyBoard> addAccompany(@RequestBody AddAccBoardRequest request) {
@@ -38,6 +41,28 @@ public class AccBoardApiController {
                 .body(accompany);
     }
 
+    @GetMapping("/api/accompany/img-path")
+    public ResponseEntity<List<ImgPathResponse>> findAllImgPath() {
+        List<ImgPathResponse> imgPath = imgPathSaveService.findAll()
+                .stream()
+                .map(ImgPathResponse::new)
+                .toList();
+
+        return ResponseEntity.ok()
+                .body(imgPath);
+    }
+
+
+    @GetMapping("/api/accompany/img-path/{board-id}")
+    public ResponseEntity<List<ImgPathResponse>> findAllByBoardIdAndBoardType(@PathVariable("board-id") Long boardId) {
+        List<ImgPathResponse> imgPath = imgPathSaveService.findAllByBoardIdAndBoardType(boardId, BoardType.ACC)
+                .stream()
+                .map(ImgPathResponse::new)
+                .toList();
+        return ResponseEntity.ok()
+                .body(imgPath);
+    }
+
     @GetMapping("/api/accompany/city/{city}")
     public ResponseEntity<List<AccBoardResponse>> findAllByCity(@PathVariable("city") String city) {
         List<AccBoardResponse> accompany = accBoardService.findByCity(city)
@@ -52,6 +77,7 @@ public class AccBoardApiController {
     @DeleteMapping("/api/accompany/{id}")
     public ResponseEntity<Void> deleteAccompany(@PathVariable("id") long id) {
         accBoardService.delete(id);
+        imgPathSaveService.delete(id,BoardType.ACC);
 
         return ResponseEntity.ok()
                 .build();

--- a/src/main/java/web/trivi/domain/AccompanyBoard.java
+++ b/src/main/java/web/trivi/domain/AccompanyBoard.java
@@ -74,8 +74,9 @@ public class AccompanyBoard {
     @Column(nullable = false)
     private String author;
 
+
     @Builder
-    public AccompanyBoard(String title, String author, BoardType boardType, AccStatus accStatus, Long totalLike, Long totalView, String content, LocalDateTime createdAt, int currentPeople, String city, String locationName, LocalDateTime meetingTime, String nation, int totalPeople){
+    public AccompanyBoard(String title, String author, BoardType boardType, AccStatus accStatus, Long totalLike, Long totalView, String content, LocalDateTime createdAt, int currentPeople, String city, String locationName, LocalDateTime meetingTime, String nation, int totalPeople, String imgPath){
         this.title = title;
         this.author = author;
         this.content = content;

--- a/src/main/java/web/trivi/domain/BoardImage.java
+++ b/src/main/java/web/trivi/domain/BoardImage.java
@@ -1,0 +1,35 @@
+package web.trivi.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@Entity
+public class BoardImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated
+    @Column(nullable = false)
+    private BoardType boardType;
+
+    @Column(nullable = false)
+    private Long boardId;
+
+    private String imgPath;
+
+    @Builder
+    public BoardImage(BoardType boardType, Long boardId, String imgPath) {
+        this.boardType = boardType;
+        this.boardId = boardId;
+        this.imgPath = imgPath;
+    }
+
+    public void update(String imgPath){
+        this.imgPath = imgPath;
+    }
+}

--- a/src/main/java/web/trivi/dto/AddAccBoardRequest.java
+++ b/src/main/java/web/trivi/dto/AddAccBoardRequest.java
@@ -25,6 +25,7 @@ public class AddAccBoardRequest {
     private String author;
     private BoardType boardType;
     private AccStatus status;
+    private String imgPath;
 
     public AccompanyBoard toEntity() {
         return AccompanyBoard.builder()

--- a/src/main/java/web/trivi/dto/AddImgPathRequest.java
+++ b/src/main/java/web/trivi/dto/AddImgPathRequest.java
@@ -1,0 +1,24 @@
+package web.trivi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import web.trivi.domain.BoardImage;
+import web.trivi.domain.BoardType;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class AddImgPathRequest {
+    private BoardType boardType;
+    private Long boardId;
+    private String imgPath;
+
+    public BoardImage toEntity(){
+        return BoardImage.builder()
+                .boardType(boardType)
+                .boardId(boardId)
+                .imgPath(imgPath)
+                .build();
+    }
+}

--- a/src/main/java/web/trivi/dto/ImgPathResponse.java
+++ b/src/main/java/web/trivi/dto/ImgPathResponse.java
@@ -1,0 +1,18 @@
+package web.trivi.dto;
+
+import lombok.Getter;
+import web.trivi.domain.BoardImage;
+import web.trivi.domain.BoardType;
+
+@Getter
+public class ImgPathResponse {
+    private BoardType boardType;
+    private Long boardId;
+    private String imgPath;
+
+    public ImgPathResponse(BoardImage boardImage) {
+        this.boardType = boardImage.getBoardType();
+        this.boardId = boardImage.getBoardId();
+        this.imgPath = boardImage.getImgPath();
+    }
+}

--- a/src/main/java/web/trivi/dto/UpdateAccBoardRequest.java
+++ b/src/main/java/web/trivi/dto/UpdateAccBoardRequest.java
@@ -11,4 +11,5 @@ public class UpdateAccBoardRequest {
     private String title;
     private String content;
     private String locationName;
+    private String imgPath;
 }

--- a/src/main/java/web/trivi/repository/BoardImgRepository.java
+++ b/src/main/java/web/trivi/repository/BoardImgRepository.java
@@ -1,0 +1,13 @@
+package web.trivi.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import web.trivi.domain.BoardImage;
+import web.trivi.domain.BoardType;
+
+import java.util.List;
+
+public interface BoardImgRepository extends JpaRepository<BoardImage, Long> {
+    BoardImage findByBoardId(Long boardId);
+    List<BoardImage> findByBoardIdAndBoardType(Long boardId, BoardType boardType);
+    void deleteByBoardIdAndBoardType(Long boardId, BoardType boardType);
+}

--- a/src/main/java/web/trivi/service/AccBoardService.java
+++ b/src/main/java/web/trivi/service/AccBoardService.java
@@ -4,10 +4,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import web.trivi.domain.AccompanyBoard;
+import web.trivi.domain.BoardImage;
+import web.trivi.domain.BoardType;
 import web.trivi.dto.AddAccBoardRequest;
+import web.trivi.dto.AddImgPathRequest;
 import web.trivi.dto.UpdateAccBoardRequest;
 import web.trivi.repository.AccBoardRepository;
-
+import web.trivi.repository.BoardImgRepository;
+import web.trivi.service.ImgPathSaveService;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,9 +19,15 @@ import java.util.Optional;
 @Service
 public class AccBoardService {
     private final AccBoardRepository accBoardRepository;
+    private final ImgPathSaveService imgPathSaveService;
+
 
     public AccompanyBoard save(AddAccBoardRequest request){
-        return accBoardRepository.save(request.toEntity());
+        AccompanyBoard accompanyBoard = accBoardRepository.save(request.toEntity());
+        if (request.getImgPath() != null){
+            imgPathSaveService.save(new AddImgPathRequest(BoardType.ACC, accompanyBoard.getId(), request.getImgPath()));
+        }
+        return accompanyBoard;
     }
 
     public List<AccompanyBoard> findAll(){
@@ -53,6 +63,10 @@ public class AccBoardService {
         }
 
         accompany.update(title, content, locationName);
+
+        if (request.getImgPath() != null) {
+            imgPathSaveService.update(id, BoardType.ACC, request.getImgPath());
+        }
 
         return accompany;
     }

--- a/src/main/java/web/trivi/service/ImgPathSaveService.java
+++ b/src/main/java/web/trivi/service/ImgPathSaveService.java
@@ -1,0 +1,55 @@
+package web.trivi.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import web.trivi.domain.BoardImage;
+import web.trivi.domain.BoardType;
+import web.trivi.dto.AddImgPathRequest;
+import web.trivi.repository.BoardImgRepository;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@RequiredArgsConstructor
+@Service
+public class ImgPathSaveService {
+    private final BoardImgRepository boardImgRepository;
+
+    public BoardImage save(AddImgPathRequest request){
+        return boardImgRepository.save(request.toEntity());
+    }
+
+    public List<BoardImage> findAll(){
+        return boardImgRepository.findAll();
+    }
+
+    public List<BoardImage> findAllByBoardIdAndBoardType(Long boardId, BoardType boardType) {
+        return boardImgRepository.findByBoardIdAndBoardType(boardId, boardType);
+    }
+
+    @Transactional
+    public void delete(Long boardId, BoardType boardType){
+        boardImgRepository.deleteByBoardIdAndBoardType(boardId, boardType);
+    }
+
+    @Transactional
+    public BoardImage update(Long boardId, BoardType boardType, String imgPath){
+        List<BoardImage> boardImages = boardImgRepository.findByBoardIdAndBoardType(boardId, boardType);
+        BoardImage boardImage = boardImages.get(0);
+        // 리스트가 비어 있으면 새 객체를 저장하고 반환합니다
+        if (boardImage == null) {
+            return boardImgRepository.save(BoardImage.builder()
+                    .boardId(boardId)
+                    .boardType(boardType)
+                    .imgPath(imgPath)
+                    .build());
+        } else {
+            boardImage.update(imgPath);
+        }
+
+        // 리스트에 항목이 있으면 첫 번째 항목을 반환합니다
+        return boardImage;
+    }
+}
+


### PR DESCRIPTION
     - 조회: 게시물 번호에 따른 이미지 주소 조회 가능
     - 수정: 이미지 수정 가능
     - 추가: 이미지가 없는 게시글을 수정시 사진이 추가될때 사진이 추가됨
     - 삭제: 게시판 삭제시 같이 삭제됨

(cherry picked from commit 578edd8888235d451ca1dcc28567509073b2173e)